### PR TITLE
fix fan_control_linked with CPU control_focus

### DIFF
--- a/defaults/fan-control.py
+++ b/defaults/fan-control.py
@@ -202,16 +202,16 @@ while True: # This is a service so it needs to run forever... so... lets make an
         if control_focus == "CPU":
             current_cpu_temp = get_cpu_temp(operating_system) #get current CPU average temp
             current_cpu_fan_speed = get_cpu_zone_speed(current_cpu_temp,cpu_fan_curve) # get what the fan speed should be based on above temp
-            if log_frequency == "Every":
+            if fan_control_linked: # set the fan speed
+                set_linked_zone_fan_speed(hardware_platform,current_cpu_fan_speed)
+            else:
+                set_cpu_zone_fan_speed(current_cpu_fan_speed)
+            if log_frequency == "Every":  # logging
                 logging.info("CPU Temp: {temp}C -> Fans: {fan_speed}".format(temp=current_cpu_temp,fan_speed=current_cpu_fan_speed)) # For each loop, write the temp then the proposed fan speed
-                set_cpu_zone_fan_speed(current_cpu_fan_speed) # set the fan speed
             if log_frequency == "On_Change":
                 if current_cpu_fan_speed > last_cpu_fan_speed or current_cpu_fan_speed < last_cpu_fan_speed:
                     last_cpu_fan_speed = current_cpu_fan_speed
                     logging.info("CPU Temp: {temp}C -> Fans: {fan_speed}".format(temp=current_cpu_temp,fan_speed=current_cpu_fan_speed)) # For each loop, write the temp then the proposed fan speed
-                    set_cpu_zone_fan_speed(current_cpu_fan_speed) # set the fan speed
-            if log_frequency == "On_Panic":
-                set_cpu_zone_fan_speed(current_cpu_fan_speed) # set the fan speed
         if control_focus == "Both":
             if fan_control_linked is True:
                 current_cpu_temp = get_cpu_temp(operating_system) #get current average temp


### PR DESCRIPTION
Hi there!

Noticed that if `control_focus == "CPU"` then code is not checking `fan_control_linked` and assumes separate fan zone layout.

---
Unnecessary rumbling: I have PERC H330 mini Raid controller in my R630 and it doesn't provide disks SMART data (that's how `smartctl` gets its metrics), so I currently can't monitor both CPU and HDD.