### PR TITLE
Correct shebang for python 3.11 instead of 3.8

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ fi
 # set some variables for the python shebangs to each OS
 TRUENASSHEBANG="#!/usr/local/bin/python3"
 PROXMOXSHEBANG="#!/usr/bin/python3"
-PFSENSESHEBANG="#!/usr/local/bin/python3.8"
+PFSENSESHEBANG="#!/usr/local/bin/python3.11"
 
 check_script_exec () {
     if [ "$1" = "2" ]; then


### PR DESCRIPTION
The manual mentions (correctly) that pfSense in newer version has python 3.11, not 3.8 - which was not reflected in the shebang in install.sh