### PR TITLE
Installer changes: Vi, not nano. Do not overwrite existing config.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,10 +69,10 @@ if [ "$USER_OS" = "1" ]; then
     echo "making appropriate files executable"
     chmod 755 /root/fan-control/gen-config.py /root/fan-control/fan-control.py /root/fan-control/fan-control.sh
     check_script_exec $USER_OS
-    echo "Starting nano to edit the config file generator that now. Ctrl+X when complete to save and exit."
+    echo "Starting vi to edit the config file generated now. Ctrl+X when complete to save and exit."
     echo "(sleeping for 10 seconds to cancel if wanted)"
     sleep 10
-    nano /root/fan-control/gen-config.py
+    vi /root/fan-control/gen-config.py
     echo "Executing gen-config.py to generate the config file"
     /root/fan-control/gen-config.py
     echo "************************"

--- a/install.sh
+++ b/install.sh
@@ -69,11 +69,13 @@ if [ "$USER_OS" = "1" ]; then
     echo "making appropriate files executable"
     chmod 755 /root/fan-control/gen-config.py /root/fan-control/fan-control.py /root/fan-control/fan-control.sh
     check_script_exec $USER_OS
-    echo "Starting nano to edit the config file generator that now. Ctrl+X when complete to save and exit."
-    echo "(sleeping for 10 seconds to cancel if wanted)"
-    sleep 10
-    nano /root/fan-control/gen-config.py
-    echo "Executing gen-config.py to generate the config file"
+    if [ ! -f config.ini ]; then
+      echo "Starting nano to edit the config file generator that now. Ctrl+X when complete to save and exit."
+      echo "(sleeping for 10 seconds to cancel if wanted)"
+      sleep 10
+      nano /root/fan-control/gen-config.py
+      echo "Executing gen-config.py to generate the config file"
+    fi
     /root/fan-control/gen-config.py
     echo "************************"
     echo "* USER ACTION REQUIRED *"
@@ -104,12 +106,14 @@ if [ "$USER_OS" = "2" ]; then
     echo "making appropriate files executable"
     chmod 755 /root/fan-control/gen-config.py /root/fan-control/fan-control.py
     check_script_exec $USER_OS
-    echo "Starting nano to edit the config file generator that now. Ctrl+X when complete to save and exit."
-    echo "(sleeping for 10 seconds to cancel if wanted)"
-    sleep 10
-    nano /root/fan-control/gen-config.py
-    echo "Executing gen-config.py to generate the config file"
-    /root/fan-control/gen-config.py
+    if [ ! -f config.ini ]; then
+      echo "Starting nano to edit the config file generator that now. Ctrl+X when complete to save and exit."
+      echo "(sleeping for 10 seconds to cancel if wanted)"
+      sleep 10
+      nano /root/fan-control/gen-config.py
+      echo "Executing gen-config.py to generate the config file"
+      /root/fan-control/gen-config.py
+    fi
     echo "Creating link to service file"
     ln -s /root/fan-control/fan-control.service /etc/systemd/system/fan-control.service
     echo "reloading daemons"

--- a/install.sh
+++ b/install.sh
@@ -135,14 +135,18 @@ if [ "$USER_OS" = "3" ]; then
     echo "making appropriate files executable"
     chmod 755 /root/fan-control/gen-config.py /root/fan-control/fan-control.py /root/fan-control/fan-control.sh
     check_script_exec $USER_OS
-    echo "Starting vi to edit the config file generated now. Quit (:wq) when complete to save and exit."
-    echo "(sleeping for 10 seconds to cancel if wanted)"
-    sleep 10
-    vi /root/fan-control/gen-config.py
-    echo "Executing gen-config.py to generate the config file"
-    /root/fan-control/gen-config.py
+    if [ ! -f config.ini ]; then
+      echo "Starting vi to edit the config file generator now. Quit (:wq) when complete to save and exit."
+      echo "(sleeping for 10 seconds to cancel if wanted)"
+      sleep 10
+      vi /root/fan-control/gen-config.py
+      echo "Executing gen-config.py to generate the config file"
+      /root/fan-control/gen-config.py
+    fi
     echo "Copying fan-control.sh to /usr/local/etc/rc.d/ so it can auto start on reboots"
     cp fan-control.sh /usr/local/etc/rc.d/
-    echo "fan-control.py is setup. Starting the script now."
+    echo "fan-control.py is setup. Starting the script."
+    echo "Ctrl+C in next 5 seconds to quit without starting the script."
+    sleep 5
     nohup /root/fan-control/fan-control.sh start & # starting this way so it won't stop when exiting the shell
 fi

--- a/install.sh
+++ b/install.sh
@@ -69,10 +69,10 @@ if [ "$USER_OS" = "1" ]; then
     echo "making appropriate files executable"
     chmod 755 /root/fan-control/gen-config.py /root/fan-control/fan-control.py /root/fan-control/fan-control.sh
     check_script_exec $USER_OS
-    echo "Starting vi to edit the config file generated now. Ctrl+X when complete to save and exit."
+    echo "Starting nano to edit the config file generator that now. Ctrl+X when complete to save and exit."
     echo "(sleeping for 10 seconds to cancel if wanted)"
     sleep 10
-    vi /root/fan-control/gen-config.py
+    nano /root/fan-control/gen-config.py
     echo "Executing gen-config.py to generate the config file"
     /root/fan-control/gen-config.py
     echo "************************"
@@ -135,10 +135,10 @@ if [ "$USER_OS" = "3" ]; then
     echo "making appropriate files executable"
     chmod 755 /root/fan-control/gen-config.py /root/fan-control/fan-control.py /root/fan-control/fan-control.sh
     check_script_exec $USER_OS
-    echo "Starting nano to edit the config file generator that now. Ctrl+X when complete to save and exit."
+    echo "Starting vi to edit the config file generated now. Quit (:wq) when complete to save and exit."
     echo "(sleeping for 10 seconds to cancel if wanted)"
     sleep 10
-    nano /root/fan-control/gen-config.py
+    vi /root/fan-control/gen-config.py
     echo "Executing gen-config.py to generate the config file"
     /root/fan-control/gen-config.py
     echo "Copying fan-control.sh to /usr/local/etc/rc.d/ so it can auto start on reboots"


### PR DESCRIPTION
This is definitely not personal preference, but nano is not installed on pfSense by default, so the command fails as written.

Vi is present.