### PR TITLE
Unset power leads to error

### DIFF
--- a/defaults/fan-control.py
+++ b/defaults/fan-control.py
@@ -78,11 +78,12 @@ def get_hdd_temp(disk_list): # this feels like a silly way to do it but it works
 
 def get_cpu_zone_speed(temp,cpu_fan_curve): # based on the fan curve, decide what the appropriate fan power level (fan speed) should be, return it as an integer.
     i = 0 # create an iterator
+    power = 100  # Set as backup, (usually) overwritten below
     while i < (len(cpu_fan_curve) - 1): # while iterator is 1 less than total length of fan curve...
         a = cpu_fan_curve[i] # set 'a' to curve temp value of iterator
         b = cpu_fan_curve[i + 1] # set 'b' to next curve temp value of iterator
 
-        if temp >= a[0] and temp <= b[0]: # if current average temperature is greater or equal to 'a' and less or equal to 'b' ...
+        if temp > a[0] and temp <= b[0]: # if current average temperature is greater or equal to 'a' and less or equal to 'b' ...
             power = a[1] + (temp - a[0]) * (b[1] - a[1]) / (b[0] - a[0]) # do some math to figure out what to set fan power to
             break
         i += 1 # bump the iterator

--- a/defaults/fan-control.py
+++ b/defaults/fan-control.py
@@ -90,6 +90,7 @@ def get_cpu_zone_speed(temp,cpu_fan_curve): # based on the fan curve, decide wha
 
 def get_hdd_zone_speed(temps,max_temp,speed_addition,hdd_fan_curve): # based on the fan curve, decide what the appropriate fan power level (fan speed) should be, return it as an integer.
     i = 0 # create an iterator
+    power = 100  # Set as backup, (usually) overwritten below
     if temps[1] >= max_temp: # if current max temp is greater than config's max temp bump the returned power by our max addition
         a = hdd_fan_curve[i] # set 'a' to curve temp value of iterator
         b = hdd_fan_curve[i + 1] # set 'b' to next curve temp value of iterator
@@ -101,7 +102,7 @@ def get_hdd_zone_speed(temps,max_temp,speed_addition,hdd_fan_curve): # based on 
             a = hdd_fan_curve[i] # set 'a' to curve temp value of iterator
             b = hdd_fan_curve[i + 1] # set 'b' to next curve temp value of iterator
 
-            if temps[0] >= a[0] and temps[0] <= b[0]: # if current average temperature is greater or equal to 'a' and less or equal to 'b' ...
+            if temps[0] > a[0] and temps[0] <= b[0]: # if current average temperature is greater or equal to 'a' and less or equal to 'b' ...
                 power = a[1] + (temps[0] - a[0]) * (b[1] - a[1]) / (b[0] - a[0]) # do some math to figure out what to set fan power to
                 break
             i += 1 # bump the iterator


### PR DESCRIPTION
In some cases, `power` would not be defined, leading to an error.

Therefore:
- make sure power is set, 100 by default as a safe backup
- change the comparison to include one of the limits